### PR TITLE
Remove DataFrames dependency.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,16 @@ authors = ["Paul Bayer"]
 version = "0.3.0"
 
 [deps]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-DataFrames = "0.19"
 DataStructures = "0.17"
 Documenter = "0.23"
+Tables = "0.2"
 Unitful = "0.17"
 julia = "1"
 

--- a/src/Simulate.jl
+++ b/src/Simulate.jl
@@ -38,7 +38,7 @@ v"0.3.0"
 """
 const version = v"0.3.0"
 
-using Unitful, Random, DataStructures, DataFrames
+using Unitful, Random, DataStructures
 import Unitful: FreeUnits, Time
 import Base.show
 


### PR DESCRIPTION
DataFrames is a heavyweight package. Implementing a simple Tables.jl-compatible
type allows users to still get a DataFrame by calling DataFrame(logger)
without carrying the dependency on DataFrames itself.